### PR TITLE
Add `tim-buck2.launchTargetPath` (and small fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
       {
         "command": "tim-buck2.compileThisFile",
         "title": "buck2: Compile Current File"
+      },
+      {
+        "command": "tim-buck2.launchTargetPath",
+        "title": "buck2: Get Launch Target Path"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Summary: `tim-buck2.launchTargetPath` allows us to reference the target currently being built by the `tim-buck2` extension in `launch.json`, so we can now debug the binaries being built with Buck2.

Test Plan: :eyes: