### PR TITLE
Small quality of life fixes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,11 @@ export function activate(context: vscode.ExtensionContext) {
             if (currentTarget === null) {
                 return null;
             }
+            // TODO: I'm not sure if this is the best way to ensure that
+            // when we're getting the path to the build target for
+            // debugging or launching, we build the latest version of
+            // the underlying binary.
+            await build();
             var out = JSON.parse(await runBuck(["build", currentTarget, "--show-json-output"]));
             return path.join(getWorkspaceRoot()!, out[currentTarget]);
         },


### PR DESCRIPTION
* Moved from a `vscode.Terminal` to a `vscode.BuildOutput`; this is nicer in that we don't really need a terminal and it has some weird behavior when you close it. This makes it clear: it's a read only output that we clear and re-use between `buck2` build invocations.
* When you restart the extension or reload the window, we now remember your build target