### PR TITLE
Add `buildCompileCommands` machinery

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
         "title": "buck2: Clean"
       },
       {
-        "command": "tim-buck2.compileThisFile",
-        "title": "buck2: Compile Current File"
-      },
-      {
         "command": "tim-buck2.launchTargetPath",
         "title": "buck2: Get Launch Target Path"
       }
@@ -52,6 +48,21 @@
           "type": "string",
           "default": "//platforms:",
           "description": "Target mask to use to look up available platforms"
+        },
+        "tim-buck2.compileCommandsGenerator": {
+          "type": "string",
+          "default": null,
+          "description": "BXL script used to generate a `compile_commands.json` (e.g. for `clangd`)"
+        },
+        "tim-buck2.compileCommandsDestination": {
+          "type": "string",
+          "default": null,
+          "description": "Destination file for a generated `compile_commands.json"
+        },
+        "tim-buck2.autoRestartClangd": {
+          "type": "boolean",
+          "default": false,
+          "description": "Restart `clangd` whenever `compile_commands.json` is generated"
         }
       }
     }


### PR DESCRIPTION
This commit adds some plumbing for a *very* specific workflow that allows you to use `tim-buck2` mostly seamlessly with `clangd` in vscode. There are some caveats:
1. You need a bxl script that builds a `compile_commands.json` and prints the path to `stdout`. It also needs to have a specific argument format (see the PR). Consider: https://github.com/facebook/buck2/pull/810
2. Due to how buck2 works, command-clicking a symbol will take you to the header file. This *is* a symlink to a real file in your repo, but it looks kind of funky.